### PR TITLE
chore: change github link to project

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -8,7 +8,7 @@
       </div>
       <nav class="flex items-center">
         <!-- <a class="mx-2 text-gray-700">Documentation</a> -->
-        <a aria-label="Github" class="mx-2" href="https://github.com/mayashavin" rel="noopener noreferrer" target="_blank">
+        <a aria-label="Github" class="mx-2" href="https://github.com/mayashavin/palette-generator/" rel="noopener noreferrer" target="_blank">
           <svg-icon name="github" class="w-6 text-gray-700 fill-current h-6 hover:text-sea-buckthorn-600"/>
         </a>
         <a aria-label="Twitter" class="mx-2" href="https://twitter.com/MayaShavin" rel="noopener noreferrer" target="_blank">


### PR DESCRIPTION
Hey 👋 

I wanted to take a look at the source code so I pushed the GitHub icon on `https://palette-generators.vercel.app/`.
I've noticed that the link goes straight to the profile and not to the repo (as I'd have expected).

Thus, I thought changing the link to the repo itself would make sense.

Of course, this is only a suggestion. If you like the current behavior, feel free to close the PR 😋 